### PR TITLE
Use throttling for rendering UI on peer events

### DIFF
--- a/packages/react-peer/package.json
+++ b/packages/react-peer/package.json
@@ -18,7 +18,7 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@cerc-io/peer": "^0.2.28",
+    "@cerc-io/peer": "^0.2.29",
     "@mui/material": "^5.11.3",
     "convert": "^4.10.0",
     "d3": "^5.5.0",

--- a/packages/react-peer/src/components/Connections.jsx
+++ b/packages/react-peer/src/components/Connections.jsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useContext, useEffect } from 'react';
+import throttle from 'lodash/throttle'
+
+import { getPseudonymForPeerId } from '@cerc-io/peer';
+import { Box, Chip, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material';
+
+import { useForceUpdate } from '../hooks/forceUpdate';
+import { PeerContext } from '../context/PeerContext';
+import { DEFAULT_REFRESH_INTERVAL, THROTTLE_WAIT_TIME } from '../constants';
+
+export function Connections ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...props }) {
+  const peer = useContext(PeerContext);
+  const forceUpdate = useForceUpdate();
+  const throttledForceUpdate = useCallback(throttle(forceUpdate, THROTTLE_WAIT_TIME), [forceUpdate]);
+
+  useEffect(() => {
+    if (!peer || !peer.node) {
+      return
+    }
+
+    // TODO: Use throttling
+    peer.node.addEventListener('peer:connect', throttledForceUpdate)
+    peer.node.addEventListener('peer:disconnect', throttledForceUpdate)
+
+    return () => {
+      peer.node?.removeEventListener('peer:connect', throttledForceUpdate)
+      peer.node?.removeEventListener('peer:disconnect', throttledForceUpdate)
+    }
+  }, [peer, throttledForceUpdate])
+
+  useEffect(() => {
+    // TODO: Add event for connection close and remove refresh in interval
+    const intervalID = setInterval(throttledForceUpdate, refreshInterval);
+
+    return () => {
+      clearInterval(intervalID)
+    }
+  }, [throttledForceUpdate])
+
+  return peer && peer.node && (
+    <Box {...props}>
+      <Typography variant="subtitle2" color="inherit" noWrap>
+        <b>
+          Remote Peer Connections
+          &nbsp;
+          <Chip size="small" label={peer.node.getConnections().length} variant="outlined" />
+        </b>
+      </Typography>
+      {peer.node.getConnections().map(connection => (
+        <TableContainer sx={{ mt: 1 }} key={connection.id} component={Paper}>
+          <Table size="small">
+            <TableBody>
+              <TableRow>
+                <TableCell size="small" sx={{ width: 150 }}><b>Connection ID</b></TableCell>
+                <TableCell size="small">{connection.id}</TableCell>
+                <TableCell size="small" align="right"><b>Direction</b></TableCell>
+                <TableCell size="small">{connection.stat.direction}</TableCell>
+                <TableCell size="small" align="right"><b>Status</b></TableCell>
+                <TableCell size="small">{connection.stat.status}</TableCell>
+                <TableCell size="small" align="right"><b>Type</b></TableCell>
+                <TableCell size="small">{connection.remoteAddr.toString().includes('p2p-circuit/p2p') ? "relayed" : "direct"}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell size="small"><b>Peer ID</b></TableCell>
+                <TableCell size="small">{`${connection.remotePeer.toString()} ( ${getPseudonymForPeerId(connection.remotePeer.toString())} )`}</TableCell>
+                <TableCell align="right"><b>Node type</b></TableCell>
+                <TableCell>
+                  {
+                    peer.isRelayPeerMultiaddr(connection.remoteAddr.toString())
+                      ? peer.isPrimaryRelay(connection.remoteAddr.toString()) ? "Relay (Primary)" : "Relay (Secondary)"
+                      : "Peer"
+                  }
+                </TableCell>
+                <TableCell size="small" align="right"><b>Latency (ms)</b></TableCell>
+                <TableCell size="small" colSpan={3}>
+                  {
+                    peer.getLatencyData(connection.remotePeer)
+                      .map((value, index) => {
+                        return index === 0 ?
+                          (<span key={index}><b>{value}</b>&nbsp;</span>) :
+                          (<span key={index}>{value}&nbsp;</span>)
+                      })
+                  }
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell size="small" sx={{ width: 150 }}><b>Connected multiaddr</b></TableCell>
+                <TableCell size="small" colSpan={7}>{connection.remoteAddr.toString()}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      ))}
+    </Box>
+  )
+}

--- a/packages/react-peer/src/components/Connections.jsx
+++ b/packages/react-peer/src/components/Connections.jsx
@@ -8,6 +8,15 @@ import { PeerContext } from '../context/PeerContext';
 import { DEFAULT_REFRESH_INTERVAL, THROTTLE_WAIT_TIME } from '../constants';
 import { useThrottledCallback } from '../hooks/throttledCallback';
 
+const STYLES = {
+  connectionsTable: {
+    marginTop: 1
+  },
+  connectionsTableFirstColumn: {
+    width: 150
+  }
+}
+
 export function Connections ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...props }) {
   const peer = useContext(PeerContext);
   const forceUpdate = useForceUpdate();
@@ -17,16 +26,15 @@ export function Connections ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...pr
 
   useEffect(() => {
     if (!peer || !peer.node) {
-      return
+      return;
     }
 
-    // TODO: Use throttling
-    peer.node.addEventListener('peer:connect', throttledForceUpdate)
-    peer.node.addEventListener('peer:disconnect', throttledForceUpdate)
+    peer.node.addEventListener('peer:connect', throttledForceUpdate);
+    peer.node.addEventListener('peer:disconnect', throttledForceUpdate);
 
     return () => {
-      peer.node?.removeEventListener('peer:connect', throttledForceUpdate)
-      peer.node?.removeEventListener('peer:disconnect', throttledForceUpdate)
+      peer.node?.removeEventListener('peer:connect', throttledForceUpdate);
+      peer.node?.removeEventListener('peer:disconnect', throttledForceUpdate);
     }
   }, [peer, throttledForceUpdate])
 
@@ -35,7 +43,7 @@ export function Connections ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...pr
     const intervalID = setInterval(throttledForceUpdate, refreshInterval);
 
     return () => {
-      clearInterval(intervalID)
+      clearInterval(intervalID);
     }
   }, [throttledForceUpdate])
 
@@ -49,11 +57,11 @@ export function Connections ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...pr
         </b>
       </Typography>
       {peer.node.getConnections().map(connection => (
-        <TableContainer sx={{ mt: 1 }} key={connection.id} component={Paper}>
+        <TableContainer sx={STYLES.connectionsTable} key={connection.id} component={Paper}>
           <Table size="small">
             <TableBody>
               <TableRow>
-                <TableCell size="small" sx={{ width: 150 }}><b>Connection ID</b></TableCell>
+                <TableCell size="small" sx={STYLES.connectionsTableFirstColumn}><b>Connection ID</b></TableCell>
                 <TableCell size="small">{connection.id}</TableCell>
                 <TableCell size="small" align="right"><b>Direction</b></TableCell>
                 <TableCell size="small">{connection.stat.direction}</TableCell>
@@ -63,7 +71,7 @@ export function Connections ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...pr
                 <TableCell size="small">{connection.remoteAddr.toString().includes('p2p-circuit/p2p') ? "relayed" : "direct"}</TableCell>
               </TableRow>
               <TableRow>
-                <TableCell size="small"><b>Peer ID</b></TableCell>
+                <TableCell size="small" sx={STYLES.connectionsTableFirstColumn}><b>Peer ID</b></TableCell>
                 <TableCell size="small">{`${connection.remotePeer.toString()} ( ${getPseudonymForPeerId(connection.remotePeer.toString())} )`}</TableCell>
                 <TableCell align="right"><b>Node type</b></TableCell>
                 <TableCell>
@@ -86,7 +94,7 @@ export function Connections ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...pr
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell size="small" sx={{ width: 150 }}><b>Connected multiaddr</b></TableCell>
+                <TableCell size="small" sx={STYLES.connectionsTableFirstColumn}><b>Connected multiaddr</b></TableCell>
                 <TableCell size="small" colSpan={7}>{connection.remoteAddr.toString()}</TableCell>
               </TableRow>
             </TableBody>

--- a/packages/react-peer/src/components/Connections.jsx
+++ b/packages/react-peer/src/components/Connections.jsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useContext, useEffect } from 'react';
-import throttle from 'lodash/throttle'
+import React, { useContext, useEffect } from 'react';
 
 import { getPseudonymForPeerId } from '@cerc-io/peer';
 import { Box, Chip, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material';
@@ -7,11 +6,14 @@ import { Box, Chip, Paper, Table, TableBody, TableCell, TableContainer, TableRow
 import { useForceUpdate } from '../hooks/forceUpdate';
 import { PeerContext } from '../context/PeerContext';
 import { DEFAULT_REFRESH_INTERVAL, THROTTLE_WAIT_TIME } from '../constants';
+import { useThrottledCallback } from '../hooks/throttledCallback';
 
 export function Connections ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...props }) {
   const peer = useContext(PeerContext);
   const forceUpdate = useForceUpdate();
-  const throttledForceUpdate = useCallback(throttle(forceUpdate, THROTTLE_WAIT_TIME), [forceUpdate]);
+
+  // Set leading false to render UI after the events have triggered
+  const throttledForceUpdate = useThrottledCallback(forceUpdate, THROTTLE_WAIT_TIME, { leading: false });
 
   useEffect(() => {
     if (!peer || !peer.node) {

--- a/packages/react-peer/src/components/NetworkGraph.jsx
+++ b/packages/react-peer/src/components/NetworkGraph.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { Graph } from 'react-d3-graph';
 import { Box, Popover, Table, TableBody, TableCell, TableContainer, TableRow, Tooltip, Typography } from '@mui/material';
+import { getPseudonymForPeerId } from '@cerc-io/peer';
 
 // Graph configuration.
 const graphConfig = {
@@ -138,7 +139,7 @@ function NetworkGraph ({ peer }) {
             <TableBody>
               <TableRow>
                 <TableCell size="small"><b>Peer ID</b></TableCell>
-                <TableCell size="small">{hoveredPeer && hoveredPeer.id}</TableCell>
+                <TableCell size="small">{hoveredPeer && `${hoveredPeer.id} ( ${getPseudonymForPeerId(hoveredPeer.id)} )`}</TableCell>
               </TableRow>
               <TableRow>
                 <TableCell size="small"><b>Multiaddr</b></TableCell>

--- a/packages/react-peer/src/components/NetworkGraph.jsx
+++ b/packages/react-peer/src/components/NetworkGraph.jsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Graph } from 'react-d3-graph';
-import { Box, Popover, Table, TableBody, TableCell, TableContainer, TableRow, Tooltip, Typography } from '@mui/material';
+import { Box, Popover, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material';
 import { getPseudonymForPeerId } from '@cerc-io/peer';
 
 // Graph configuration.
-const graphConfig = {
+const GRAPH_CONFIG = {
   nodeHighlightBehavior: true,
   node: {
       color: 'blue',
@@ -44,13 +44,31 @@ const graphConfig = {
   width: window.innerWidth - 64
 };
 
-function NetworkGraph ({ peer }) {
+function NetworkGraph ({ peer, connections }) {
   const links = [];
   const relayMultiaddr = peer.relayNodeMultiaddr
   const [anchorEl, setAnchorEl] = useState(null)
   const [hoveredPeer, setHoveredPeer] = useState(null)
+  const [prevConnections, setPrevConnections] = useState(connections.map(connection => connection.id))
+  const [graphKey, setGraphKey] = useState('')
 
-  const remotePeerNodes = peer.node.getConnections().map(connection => {
+  // Issue with links in graph not getting removed after disconnect
+  // Workaround to re render graph after disconnects between peers
+  useEffect(() => {
+    const connectionIds = connections.map(connection => connection.id)
+    // Compare connections and check if any previous connection missing
+    const isConnectionMissing = prevConnections.some(connectionId => !connectionIds.includes(connectionId));
+    
+    if (isConnectionMissing) {
+      setGraphKey(JSON.stringify(connectionIds));
+    }
+
+    return () => {
+      setPrevConnections(connections.map(connection => connection.id))
+    }
+  }, [connections])
+
+  const remotePeerNodes = connections.map(connection => {
     const connectionMultiAddr = connection.remoteAddr
     
     const nodeData = {
@@ -110,9 +128,10 @@ function NetworkGraph ({ peer }) {
   return (
     <Box>
       <Graph
+        key={graphKey}
         id="network-graph"
         data={data}
-        config={graphConfig}
+        config={GRAPH_CONFIG}
         onMouseOverNode={onMouseOverNode}
         onMouseOutNode={() => setAnchorEl(null)}
       />
@@ -144,7 +163,7 @@ function NetworkGraph ({ peer }) {
               <TableRow>
                 <TableCell size="small"><b>Multiaddr</b></TableCell>
                 <TableCell size="small">
-                  {hoveredPeer && hoveredPeer.multiaddrs.map(multiaddr => (<Typography variant="body2">{multiaddr}</Typography>))}
+                  {hoveredPeer && hoveredPeer.multiaddrs.map(multiaddr => (<Typography key={multiaddr} variant="body2">{multiaddr}</Typography>))}
                 </TableCell>
               </TableRow>
             </TableBody>

--- a/packages/react-peer/src/components/PeerNetwork.jsx
+++ b/packages/react-peer/src/components/PeerNetwork.jsx
@@ -1,5 +1,4 @@
-import React, { useContext, useEffect, useCallback } from 'react';
-import throttle from 'lodash/throttle'
+import React, { useContext, useEffect } from 'react';
 
 import { Box } from '@mui/material';
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
@@ -8,11 +7,14 @@ import { useForceUpdate } from '../hooks/forceUpdate';
 import { PeerContext } from '../context/PeerContext';
 import { DEFAULT_REFRESH_INTERVAL, THROTTLE_WAIT_TIME } from '../constants';
 import NetworkGraph from './NetworkGraph';
+import { useThrottledCallback } from '../hooks/throttledCallback';
 
 export function PeerNetwork ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...props }) {
   const peer = useContext(PeerContext);
   const forceUpdate = useForceUpdate();
-  const throttledForceUpdate = useCallback(throttle(forceUpdate, THROTTLE_WAIT_TIME), [forceUpdate]);
+
+  // Set leading false to render UI after the events have triggered
+  const throttledForceUpdate = useThrottledCallback(forceUpdate, THROTTLE_WAIT_TIME, { leading: false });
 
   useEffect(() => {
     if (!peer || !peer.node) {

--- a/packages/react-peer/src/components/PeerNetwork.jsx
+++ b/packages/react-peer/src/components/PeerNetwork.jsx
@@ -1,45 +1,45 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useCallback } from 'react';
+import throttle from 'lodash/throttle'
 
 import { Box } from '@mui/material';
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
 
 import { useForceUpdate } from '../hooks/forceUpdate';
 import { PeerContext } from '../context/PeerContext';
-import { DEFAULT_REFRESH_INTERVAL } from '../constants';
+import { DEFAULT_REFRESH_INTERVAL, THROTTLE_WAIT_TIME } from '../constants';
 import NetworkGraph from './NetworkGraph';
 
 export function PeerNetwork ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...props }) {
-  const forceUpdate = useForceUpdate();
   const peer = useContext(PeerContext);
+  const forceUpdate = useForceUpdate();
+  const throttledForceUpdate = useCallback(throttle(forceUpdate, THROTTLE_WAIT_TIME), [forceUpdate]);
 
   useEffect(() => {
     if (!peer || !peer.node) {
       return
     }
 
-    peer.node.peerStore.addEventListener('change:multiaddrs', forceUpdate)
-    peer.node.addEventListener('peer:connect', forceUpdate)
-    peer.node.addEventListener('peer:disconnect', forceUpdate)
+    peer.node.addEventListener('peer:connect', throttledForceUpdate)
+    peer.node.addEventListener('peer:disconnect', throttledForceUpdate)
 
     return () => {
-      peer.node?.peerStore.removeEventListener('change:multiaddrs', forceUpdate)
-      peer.node?.removeEventListener('peer:connect', forceUpdate)
-      peer.node?.removeEventListener('peer:disconnect', forceUpdate)
+      peer.node?.removeEventListener('peer:connect', throttledForceUpdate)
+      peer.node?.removeEventListener('peer:disconnect', throttledForceUpdate)
     }
-  }, [peer, forceUpdate])
+  }, [peer, throttledForceUpdate])
 
   useEffect(() => {
     // TODO: Add event for connection close and remove refresh in interval
-    const intervalID = setInterval(forceUpdate, refreshInterval);
+    const intervalID = setInterval(throttledForceUpdate, refreshInterval);
 
     return () => {
       clearInterval(intervalID)
     }
-  }, [forceUpdate])
+  }, [throttledForceUpdate])
 
   return (
     <ScopedCssBaseline>
-      <Box mt={1}>
+      <Box mt={1} {...props}>
         { peer && (
           <NetworkGraph
             peer={peer}

--- a/packages/react-peer/src/components/PeerNetwork.jsx
+++ b/packages/react-peer/src/components/PeerNetwork.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 
 import { Box } from '@mui/material';
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
@@ -11,9 +11,9 @@ import { useThrottledCallback } from '../hooks/throttledCallback';
 
 export function PeerNetwork ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...props }) {
   const peer = useContext(PeerContext);
-  const forceUpdate = useForceUpdate();
-
+  
   // Set leading false to render UI after the events have triggered
+  const forceUpdate = useForceUpdate();
   const throttledForceUpdate = useThrottledCallback(forceUpdate, THROTTLE_WAIT_TIME, { leading: false });
 
   useEffect(() => {
@@ -44,6 +44,7 @@ export function PeerNetwork ({ refreshInterval = DEFAULT_REFRESH_INTERVAL, ...pr
       <Box mt={1} {...props}>
         { peer && (
           <NetworkGraph
+            connections={[...peer.node.getConnections()]}
             peer={peer}
           />
         )}

--- a/packages/react-peer/src/components/SelfInfo.jsx
+++ b/packages/react-peer/src/components/SelfInfo.jsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
+import throttle from 'lodash/throttle';
 
 import { getPseudonymForPeerId } from '@cerc-io/peer';
-import { Box, Button, Chip, FormControl, Grid, InputLabel, MenuItem, Paper, Select, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material';
+import { Box, Button, FormControl, Grid, InputLabel, MenuItem, Paper, Select, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material';
 
 import { useForceUpdate } from '../hooks/forceUpdate';
 import { PeerContext } from '../context/PeerContext';
-import { DEFAULT_REFRESH_INTERVAL } from '../constants';
+import { DEFAULT_REFRESH_INTERVAL, THROTTLE_WAIT_TIME } from '../constants';
 
 const STYLES = {
   selfInfoHead: {
@@ -15,18 +16,16 @@ const STYLES = {
     marginRight: 1,
     minWidth: 200
   },
-  selfInfoTable: {
-    marginBottom: 2
-  },
   nodeStartedTableCell: {
     width: 150
   }
 }
 
-export function DebugInfo ({ relayNodes, refreshInterval = DEFAULT_REFRESH_INTERVAL, ...props }) {
-  const forceUpdate = useForceUpdate();
+export function SelfInfo ({ relayNodes, refreshInterval = DEFAULT_REFRESH_INTERVAL, ...props }) {
   const peer = useContext(PeerContext);
   const [primaryRelay, setPrimaryRelay] = useState(localStorage.getItem('primaryRelay') ?? '')
+  const forceUpdate = useForceUpdate();
+  const throttledForceUpdate = useCallback(throttle(forceUpdate, THROTTLE_WAIT_TIME), [forceUpdate]);
 
   const handlePrimaryRelayChange = useCallback(() => {
     // Set selected primary relay in localStorage and refresh app
@@ -39,25 +38,21 @@ export function DebugInfo ({ relayNodes, refreshInterval = DEFAULT_REFRESH_INTER
       return
     }
 
-    peer.node.peerStore.addEventListener('change:multiaddrs', forceUpdate)
-    peer.node.addEventListener('peer:connect', forceUpdate)
-    peer.node.addEventListener('peer:disconnect', forceUpdate)
+    peer.node.peerStore.addEventListener('change:multiaddrs', throttledForceUpdate)
 
     return () => {
-      peer.node?.peerStore.removeEventListener('change:multiaddrs', forceUpdate)
-      peer.node?.removeEventListener('peer:connect', forceUpdate)
-      peer.node?.removeEventListener('peer:disconnect', forceUpdate)
+      peer.node?.peerStore.removeEventListener('change:multiaddrs', throttledForceUpdate)
     }
-  }, [peer, forceUpdate])
+  }, [peer, throttledForceUpdate])
 
   useEffect(() => {
     // TODO: Add event for connection close and remove refresh in interval
-    const intervalID = setInterval(forceUpdate, refreshInterval);
+    const intervalID = setInterval(throttledForceUpdate, refreshInterval);
 
     return () => {
       clearInterval(intervalID)
     }
-  }, [forceUpdate])
+  }, [throttledForceUpdate])
 
   return (
     <Box {...props}>
@@ -103,7 +98,7 @@ export function DebugInfo ({ relayNodes, refreshInterval = DEFAULT_REFRESH_INTER
           </Box>
         </Grid>
       </Grid>
-      <TableContainer sx={STYLES.selfInfoTable} component={Paper}>
+      <TableContainer component={Paper}>
         <Table size="small">
           <TableBody>
             <TableRow>
@@ -139,64 +134,6 @@ export function DebugInfo ({ relayNodes, refreshInterval = DEFAULT_REFRESH_INTER
           </TableBody>
         </Table>
       </TableContainer>
-      {
-        peer && peer.node && (
-          <>
-            <Typography variant="subtitle2" color="inherit" noWrap>
-              <b>
-                Remote Peer Connections
-                &nbsp;
-                <Chip size="small" label={peer.node.getConnections().length} variant="outlined" />
-              </b>
-            </Typography>
-            {peer.node.getConnections().map(connection => (
-              <TableContainer sx={{ mt: 1 }} key={connection.id} component={Paper}>
-                <Table size="small">
-                  <TableBody>
-                    <TableRow>
-                      <TableCell size="small" sx={{ width: 150 }}><b>Connection ID</b></TableCell>
-                      <TableCell size="small">{connection.id}</TableCell>
-                      <TableCell size="small" align="right"><b>Direction</b></TableCell>
-                      <TableCell size="small">{connection.stat.direction}</TableCell>
-                      <TableCell size="small" align="right"><b>Status</b></TableCell>
-                      <TableCell size="small">{connection.stat.status}</TableCell>
-                      <TableCell size="small" align="right"><b>Type</b></TableCell>
-                      <TableCell size="small">{connection.remoteAddr.toString().includes('p2p-circuit/p2p') ? "relayed" : "direct"}</TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell size="small"><b>Peer ID</b></TableCell>
-                      <TableCell size="small">{`${connection.remotePeer.toString()} ( ${getPseudonymForPeerId(connection.remotePeer.toString())} )`}</TableCell>
-                      <TableCell align="right"><b>Node type</b></TableCell>
-                      <TableCell>
-                        {
-                          peer.isRelayPeerMultiaddr(connection.remoteAddr.toString())
-                            ? peer.isPrimaryRelay(connection.remoteAddr.toString()) ? "Relay (Primary)" : "Relay (Secondary)"
-                            : "Peer"
-                        }
-                      </TableCell>
-                      <TableCell size="small" align="right"><b>Latency (ms)</b></TableCell>
-                      <TableCell size="small" colSpan={3}>
-                        {
-                          peer.getLatencyData(connection.remotePeer)
-                            .map((value, index) => {
-                              return index === 0 ?
-                                (<span key={index}><b>{value}</b>&nbsp;</span>) :
-                                (<span key={index}>{value}&nbsp;</span>)
-                            })
-                        }
-                      </TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell size="small" sx={{ width: 150 }}><b>Connected multiaddr</b></TableCell>
-                      <TableCell size="small" colSpan={7}>{connection.remoteAddr.toString()}</TableCell>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            ))}
-          </>
-        )
-      }
     </Box>
   )
 }

--- a/packages/react-peer/src/components/SelfInfo.jsx
+++ b/packages/react-peer/src/components/SelfInfo.jsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import throttle from 'lodash/throttle';
 
 import { getPseudonymForPeerId } from '@cerc-io/peer';
 import { Box, Button, FormControl, Grid, InputLabel, MenuItem, Paper, Select, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material';
@@ -7,6 +6,7 @@ import { Box, Button, FormControl, Grid, InputLabel, MenuItem, Paper, Select, Ta
 import { useForceUpdate } from '../hooks/forceUpdate';
 import { PeerContext } from '../context/PeerContext';
 import { DEFAULT_REFRESH_INTERVAL, THROTTLE_WAIT_TIME } from '../constants';
+import { useThrottledCallback } from '../hooks/throttledCallback';
 
 const STYLES = {
   selfInfoHead: {
@@ -25,7 +25,8 @@ export function SelfInfo ({ relayNodes, refreshInterval = DEFAULT_REFRESH_INTERV
   const peer = useContext(PeerContext);
   const [primaryRelay, setPrimaryRelay] = useState(localStorage.getItem('primaryRelay') ?? '')
   const forceUpdate = useForceUpdate();
-  const throttledForceUpdate = useCallback(throttle(forceUpdate, THROTTLE_WAIT_TIME), [forceUpdate]);
+
+  const throttledForceUpdate = useThrottledCallback(forceUpdate, THROTTLE_WAIT_TIME);
 
   const handlePrimaryRelayChange = useCallback(() => {
     // Set selected primary relay in localStorage and refresh app

--- a/packages/react-peer/src/constants.js
+++ b/packages/react-peer/src/constants.js
@@ -1,1 +1,3 @@
 export const DEFAULT_REFRESH_INTERVAL = 5000; // ms
+
+export const THROTTLE_WAIT_TIME = 1000; // ms

--- a/packages/react-peer/src/context/PeerProvider.js
+++ b/packages/react-peer/src/context/PeerProvider.js
@@ -4,8 +4,14 @@ import { Peer, createPeerId } from '@cerc-io/peer';
 
 import { PeerContext } from './PeerContext';
 
+const PEER_INIT_CONFIG = {
+  maxConnections: 100,
+  maxRelayConnections: 5
+};
+
 export const PeerProvider = ({ relayNodes, children }) => {
   const [peer, setPeer] = React.useState(null);
+  const [initConfig, setInitConfig] = React.useState(PEER_INIT_CONFIG);
 
   React.useEffect(() => {
     const init = async () => {
@@ -35,7 +41,7 @@ export const PeerProvider = ({ relayNodes, children }) => {
         peerIdObj = await createPeerId();
       }
 
-      await peer.init(peerIdObj);
+      await peer.init(initConfig, peerIdObj);
 
       // Debug
       console.log(`Peer ID: ${peer.peerId.toString()}`);

--- a/packages/react-peer/src/hooks/forceUpdate.js
+++ b/packages/react-peer/src/hooks/forceUpdate.js
@@ -2,10 +2,11 @@
 // Copyright 2023 Vulcanize, Inc.
 //
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export function useForceUpdate(){
     const [, setValue] = useState(0); // integer state
+    const forceUpdate = useCallback(() => setValue(value => value + 1), [setValue]); // update state to force render
 
-    return () => setValue(value => value + 1); // update state to force render
+    return forceUpdate;
 }

--- a/packages/react-peer/src/hooks/throttledCallback.js
+++ b/packages/react-peer/src/hooks/throttledCallback.js
@@ -1,0 +1,11 @@
+//
+// Copyright 2023 Vulcanize, Inc.
+//
+
+import { useCallback } from 'react';
+import throttle from 'lodash/throttle'
+
+export function useThrottledCallback(callback, waitTime, options){
+  const throttledCallback = useCallback(throttle(callback, waitTime, options), [callback]);
+  return throttledCallback;
+}

--- a/packages/react-peer/src/index.js
+++ b/packages/react-peer/src/index.js
@@ -1,5 +1,6 @@
 export { PeerContext } from './context/PeerContext';
 export { PeerProvider } from './context/PeerProvider';
 export { Metrics } from './components/Metrics';
-export { DebugInfo } from './components/DebugInfo';
+export { SelfInfo } from './components/SelfInfo';
+export { Connections } from './components/Connections';
 export { PeerNetwork } from './components/PeerNetwork';

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.28",
   "private": true,
   "dependencies": {
-    "@cerc-io/peer": "^0.2.28",
+    "@cerc-io/peer": "^0.2.29",
     "@cerc-io/react-peer": "^0.2.28",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",

--- a/packages/test-app/src/App.tsx
+++ b/packages/test-app/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import { PeerContext, Metrics, DebugInfo, PeerNetwork } from '@cerc-io/react-peer'
+import { PeerContext, Metrics, SelfInfo, Connections, PeerNetwork } from '@cerc-io/react-peer'
 
 import { Peer } from '@cerc-io/peer';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -84,13 +84,18 @@ function App() {
         >
           <Card raised>
             <CardContent sx={STYLES.cardContent}>
-              <DebugInfo relayNodes={config.relayNodes ?? []} />
+              <SelfInfo relayNodes={config.relayNodes ?? []} />
             </CardContent>
           </Card>
           <Card sx={{ marginTop: 2 }} raised>
             <CardContent sx={STYLES.cardContent}>
               <Typography><b>Graph</b></Typography>
               <PeerNetwork />
+            </CardContent>
+          </Card>
+          <Card sx={{ marginTop: 2 }} raised>
+            <CardContent sx={STYLES.cardContent}>
+              <Connections />
             </CardContent>
           </Card>
           <Card sx={{ marginTop: 2 }} raised>

--- a/packages/test-app/src/App.tsx
+++ b/packages/test-app/src/App.tsx
@@ -11,10 +11,20 @@ import './App.css';
 const TEST_TOPIC = 'test';
 
 const STYLES = {
+  container: {
+    bgcolor: 'background.paper',
+    py: 3,
+    px: 3
+  },
   cardContent: {
     padding: 1,
     '&:last-child': {
       padding: 1
+    }
+  },
+  debugCard: {
+    '&:not(:first-of-type)': {
+      marginTop: 2
     }
   }
 }
@@ -76,29 +86,25 @@ function App() {
       </AppBar>
       <main>
         <Box
-          sx={{
-            bgcolor: 'background.paper',
-            py: 3,
-            px: 3
-          }}
+          sx={STYLES.container}
         >
-          <Card raised>
+          <Card sx={STYLES.debugCard} raised>
             <CardContent sx={STYLES.cardContent}>
               <SelfInfo relayNodes={config.relayNodes ?? []} />
             </CardContent>
           </Card>
-          <Card sx={{ marginTop: 2 }} raised>
+          <Card sx={STYLES.debugCard} raised>
             <CardContent sx={STYLES.cardContent}>
               <Typography><b>Graph</b></Typography>
               <PeerNetwork />
             </CardContent>
           </Card>
-          <Card sx={{ marginTop: 2 }} raised>
+          <Card sx={STYLES.debugCard} raised>
             <CardContent sx={STYLES.cardContent}>
               <Connections />
             </CardContent>
           </Card>
-          <Card sx={{ marginTop: 2 }} raised>
+          <Card sx={STYLES.debugCard} raised>
             <CardContent sx={STYLES.cardContent}>
               <Typography><b>Metrics</b></Typography>
               <Metrics />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,10 +1485,10 @@
     wherearewe "^2.0.0"
     xsalsa20 "^1.1.0"
 
-"@cerc-io/peer@^0.2.28":
-  version "0.2.28"
-  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fpeer/-/0.2.28/peer-0.2.28.tgz#b3fbaafa02045f2c1a782aa4ef9f8312a3f44b65"
-  integrity sha512-YLdQ+7Wyr1k7QxMKd3LkB05RNdX6h/nMKjRLsD8WokEaThzoCruTRU0Fx/lCbgQeHM2mOjLrymF9J9yTnyF/IA==
+"@cerc-io/peer@^0.2.29":
+  version "0.2.29"
+  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fpeer/-/0.2.29/peer-0.2.29.tgz#3bb7a5ee8bddbbf1d398d351f7350d171ce2395f"
+  integrity sha512-3glSrQHDS8AzqTjvHe5VWfV0Ob22EhZBsPYV+rJjqZNtRRkn5bOIO2lu+wVHEFz8bY/Kf7mz5a+Bx/U9IXn6jA==
   dependencies:
     "@cerc-io/libp2p" "0.42.2-laconic-0.1.1"
     "@cerc-io/prometheus-metrics" "1.1.4"


### PR DESCRIPTION
Part of cerc-io/watcher-ts#289

- Pass peer initialization config (https://github.com/cerc-io/watcher-ts/pull/328)
- Show pseudonym on hovering nodes in graph
- Use throttling for rendering UI on immediate consecutive events
- Show connections list below graph
- Workaround for links in graph not getting removed after peer disconnects
  - Re-rendering UI when connection is removed