### PR TITLE
Upgrade cerc-io peer package

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "0.2.34",
+  "version": "0.2.35",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/packages/example-libp2p-app/package.json
+++ b/packages/example-libp2p-app/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@cerc-io/example-libp2p-app",
-  "version": "0.1.0",
+  "version": "0.2.35",
   "private": true,
   "license": "AGPL-3.0",
   "dependencies": {
-    "libp2p": "^0.45.0",
-    "@cerc-io/react-libp2p-debug": "^0.2.34",
+    "@cerc-io/react-libp2p-debug": "^0.2.35",
     "@chainsafe/libp2p-noise": "^12.0.0",
     "@libp2p/bootstrap": "^8.0.0",
     "@libp2p/mplex": "^8.0.1",
@@ -18,6 +17,7 @@
     "@types/node": "^16.18.10",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
+    "libp2p": "^0.45.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/packages/libp2p-util/package.json
+++ b/packages/libp2p-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/libp2p-util",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "libp2p utils module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.47.1",
-    "libp2p": "^0.42.2",
     "eslint": "^8.35.0",
     "eslint-config-semistandard": "^15.0.1",
     "eslint-config-standard": "^16.0.3",
@@ -23,6 +22,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
+    "libp2p": "^0.42.2",
     "typescript": "^5.0.4"
   },
   "dependencies": {

--- a/packages/react-libp2p-debug/package.json
+++ b/packages/react-libp2p-debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/react-libp2p-debug",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "react-libp2p-debug React component",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -29,10 +29,10 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@cerc-io/libp2p-util": "^0.2.34",
+    "@cerc-io/libp2p-util": "^0.2.35",
+    "@mui/icons-material": "^5.11.3",
     "@mui/lab": "^5.0.0-alpha.121",
     "@mui/material": "^5.11.3",
-    "@mui/icons-material": "^5.11.3",
     "d3": "^5.5.0",
     "lodash": "^4.17.21",
     "use-resize-observer": "^9.1.0"

--- a/packages/react-peer/package.json
+++ b/packages/react-peer/package.json
@@ -19,7 +19,7 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@cerc-io/peer": "^0.2.43",
+    "@cerc-io/peer": "^0.2.50",
     "@cerc-io/libp2p-util": "^0.2.34",
     "@cerc-io/react-libp2p-debug": "^0.2.34",
     "@mui/lab": "^5.0.0-alpha.121",

--- a/packages/react-peer/package.json
+++ b/packages/react-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/react-peer",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "react-peer React component",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -19,9 +19,9 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
+    "@cerc-io/libp2p-util": "^0.2.35",
     "@cerc-io/peer": "^0.2.50",
-    "@cerc-io/libp2p-util": "^0.2.34",
-    "@cerc-io/react-libp2p-debug": "^0.2.34",
+    "@cerc-io/react-libp2p-debug": "^0.2.35",
     "@mui/lab": "^5.0.0-alpha.121",
     "@mui/material": "^5.11.3",
     "convert": "^4.10.0",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@cerc-io/test-app",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "files": [
     "build/*"
   ],
   "dependencies": {
+    "@cerc-io/libp2p-util": "^0.2.35",
     "@cerc-io/peer": "^0.2.43",
-    "@cerc-io/libp2p-util": "^0.2.34",
-    "@cerc-io/react-peer": "^0.2.34",
-    "@cerc-io/react-libp2p-debug": "^0.2.34",
+    "@cerc-io/react-libp2p-debug": "^0.2.35",
+    "@cerc-io/react-peer": "^0.2.35",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mui/material": "^5.11.3",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "license": "AGPL-3.0",
   "private": true,
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,6 +1526,34 @@
     unique-names-generator "^4.7.1"
     yargs "^17.0.1"
 
+"@cerc-io/peer@^0.2.50":
+  version "0.2.50"
+  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fpeer/-/0.2.50/peer-0.2.50.tgz#79c480ae24e59b68ee1ac724dc90ce706b85a7d0"
+  integrity sha512-/+rv7iu5oxMKW+t+BisyMJmF8zAFIPVDRIxZ8gpzVvjNUJBKmxKZsjckQoxEoqdEYKBwc8nNxzSs6Y9qG4pnGg==
+  dependencies:
+    "@cerc-io/libp2p" "0.42.2-laconic-0.1.3"
+    "@cerc-io/prometheus-metrics" "1.1.4"
+    "@chainsafe/libp2p-noise" "^11.0.0"
+    "@libp2p/floodsub" "^6.0.0"
+    "@libp2p/mplex" "^7.1.1"
+    "@libp2p/peer-id-factory" "^2.0.0"
+    "@libp2p/pubsub-peer-discovery" "^8.0.0"
+    "@libp2p/websockets" "^5.0.5"
+    "@multiformats/multiaddr" "^11.1.4"
+    assert "^2.0.0"
+    buffer "^6.0.3"
+    chai "^4.3.4"
+    debug "^4.3.1"
+    it-length-prefixed "^8.0.4"
+    it-map "^2.0.0"
+    it-pipe "^2.0.5"
+    it-pushable "^3.1.2"
+    mocha "^8.4.0"
+    p-event "^5.0.1"
+    uint8arrays "^4.0.3"
+    unique-names-generator "^4.7.1"
+    yargs "^17.0.1"
+
 "@cerc-io/prometheus-metrics@1.1.4":
   version "1.1.4"
   resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fprometheus-metrics/-/1.1.4/prometheus-metrics-1.1.4.tgz#51006b0b5bf6168394390c78072a1c0bb2b02f28"


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/321

- Required for accommodating the fix done in https://github.com/cerc-io/watcher-ts/pull/394 in `@cerc-io/peer` for a WebRTC connection stability issue between two browser peers