### PR TITLE
Use lerna from packages in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,4 +26,4 @@ jobs:
           npm config set -- '//git.vdb.to/api/packages/cerc-io/npm/:_authToken' "${{ secrets.GITEA_PUBLISH_TOKEN }}"
       - name: lerna publish
         run: |
-          lerna publish from-package --no-git-tag-version --yes
+          yarn lerna publish from-package --no-git-tag-version --yes

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "0.2.35",
+  "version": "0.2.36",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/packages/example-libp2p-app/package.json
+++ b/packages/example-libp2p-app/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/example-libp2p-app",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "private": true,
   "license": "AGPL-3.0",
   "dependencies": {
-    "@cerc-io/react-libp2p-debug": "^0.2.35",
+    "@cerc-io/react-libp2p-debug": "^0.2.36",
     "@chainsafe/libp2p-noise": "^12.0.0",
     "@libp2p/bootstrap": "^8.0.0",
     "@libp2p/mplex": "^8.0.1",

--- a/packages/libp2p-util/package.json
+++ b/packages/libp2p-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/libp2p-util",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "libp2p utils module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/react-libp2p-debug/package.json
+++ b/packages/react-libp2p-debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/react-libp2p-debug",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "react-libp2p-debug React component",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -29,7 +29,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@cerc-io/libp2p-util": "^0.2.35",
+    "@cerc-io/libp2p-util": "^0.2.36",
     "@mui/icons-material": "^5.11.3",
     "@mui/lab": "^5.0.0-alpha.121",
     "@mui/material": "^5.11.3",

--- a/packages/react-peer/package.json
+++ b/packages/react-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/react-peer",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "react-peer React component",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -19,9 +19,9 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@cerc-io/libp2p-util": "^0.2.35",
+    "@cerc-io/libp2p-util": "^0.2.36",
     "@cerc-io/peer": "^0.2.50",
-    "@cerc-io/react-libp2p-debug": "^0.2.35",
+    "@cerc-io/react-libp2p-debug": "^0.2.36",
     "@mui/lab": "^5.0.0-alpha.121",
     "@mui/material": "^5.11.3",
     "convert": "^4.10.0",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@cerc-io/test-app",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "files": [
     "build/*"
   ],
   "dependencies": {
-    "@cerc-io/libp2p-util": "^0.2.35",
+    "@cerc-io/libp2p-util": "^0.2.36",
     "@cerc-io/peer": "^0.2.43",
-    "@cerc-io/react-libp2p-debug": "^0.2.35",
-    "@cerc-io/react-peer": "^0.2.35",
+    "@cerc-io/react-libp2p-debug": "^0.2.36",
+    "@cerc-io/react-peer": "^0.2.36",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mui/material": "^5.11.3",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "license": "AGPL-3.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
- Use `yarn lerna` to force usage of `lerna` version from the repo